### PR TITLE
Add type:module directive

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "vue3-recaptcha-v2",
   "version": "1.0.0",
   "description": "reCAPTCHA for Vue3 : CompositionAPI, Types",
+  "type": "module",
   "main": "dist/vue3-recaptcha-v2.js",
   "types": "dist/vue3-recaptcha-v2.d.ts",
   "repository": {


### PR DESCRIPTION
Fix warning: vue3-recaptcha-v2 doesn't appear to be written in CJS, but also doesn't appear to be a valid ES module