### PR TITLE
fix: create script function is call duplicate

### DIFF
--- a/src/composables/useInstall.ts
+++ b/src/composables/useInstall.ts
@@ -17,6 +17,11 @@ export const useInstall = () => {
       throw new ReCaptchaError("Cannot generate script on server side");
     }
 
+    const el = document.getElementById(RECAPTCHA_SCRIPT_ID);
+    if (el) {
+      el.remove()
+    }
+
     const script = document.createElement("script");
     const src = options?.cnDomains ? GOOGLE_DOMAINS_CN : GOOGLE_DOMAINS;
     const lang = language ? `&hl=${language}` : "";


### PR DESCRIPTION
When working in SPA mode, a bug occurs if a plugin is integrated on several pages. When transitioning from one page to another, an additional script is added, and everything breaks.